### PR TITLE
Additional .yaml file for config app

### DIFF
--- a/R/load_config.R
+++ b/R/load_config.R
@@ -1,0 +1,30 @@
+library(yaml)
+
+#' Load config file from YAML
+#'
+#' Loads an scExploreR object-specific .yaml config file and converts all
+#' elements in the config list to the correct R data structures.
+#'
+#' @param path A path to a YAML file storing object-specific config info. 
+#'
+load_config <- 
+  function(path){
+    # Load config YAML using defined path
+    config_r <- read_yaml(path)
+    
+    # Convert the "adt_thresholds" section to a tibble, if defined
+    if (isTruthy(config_r$adt_thresholds)){
+      config_r$adt_thresholds <-
+        as_tibble(config_r$adt_thresholds)
+    } else {
+      # If adt_thresholds is NULL ("~" in YAML file), create a blank tibble 
+      # with threshold-specific columns 
+      config_r$adt_thresholds <-
+        tibble(
+          `adt` = character(0), 
+          `value` = numeric(0)
+        )
+      }
+    
+    config_r
+    }

--- a/config_init.yaml
+++ b/config_init.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+# Enter the path to an object to use as the basis for the new config file
+object_path: ./Seurat_Objects/longitudinal_samples_20211025.rds
+  #./Seurat_Objects/Ian_Browser/ssp925_dk_dX_326_925_20220820_scE.rds
+
+# Enter the path of a previously created config file and press the load button
+# in the app to continue editing it
+config_path: ./Seurat_Objects/d0-d30-config.yaml
+  #./Seurat_Objects/Ian_Browser/ssp925_dk_dX_326_925_20220820_scE_config.rds


### PR DESCRIPTION
The user now uses `config_init.yaml` to specify the paths for the object and config file instead of directly editing `config_app.r`. This is not as user friendly as using an interface within the config app to load an object or config file, but it is much easier to implement.