### PR TITLE
Fix #152

### DIFF
--- a/R/run_config_app.R
+++ b/R/run_config_app.R
@@ -1985,6 +1985,21 @@ run_config <-
               # Delete the selected row from the table and save the new table
               module_data$threshold_data <-
                 module_data$threshold_data[-row_selected,]
+              
+              # Add the ADT corresponding to the row to be deleted back to the
+              # list of available ADTs, by updating the select input with all
+              # ADTs not in the new table
+              adts <- 
+                object[[ADT_assay()]] |> 
+                rownames()
+              
+              updateSelectizeInput(
+                session = session,
+                inputId = "selected_adt",
+                choices = adts[!adts %in% module_data$threshold_data$adt],
+                selected = character(0),
+                server = TRUE
+                )
             } else {
               warning("Unable to determine the index of the row selected for deletion")
             }


### PR DESCRIPTION
When adding an ADT threshold, the selectize input menus are updated with the ADTs that are not currently in the threshold table. This should also happen when ADT features are deleted from the table, but the code to achieve this was not present in the deletion section. The code has been added here, and features now re-populate as expected when they are deleted from the table.