### PR TITLE
Fix #167

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     RColorBrewer,
     reactlog (>= 1.1.0),
     rintrojs (>= 0.3.0),
+    rlang,
     rlog (>= 0.1.0),
     scales,
     Seurat (>= 3.0.0),

--- a/R/run_scExploreR.R
+++ b/R/run_scExploreR.R
@@ -68,6 +68,7 @@ run_scExploreR <-
     
     # Other packages
     library(yaml, quietly = TRUE, warn.conflicts = FALSE)
+    library(rlang, quietly = TRUE, warn.conflicts = FALSE)
     
     # Add inst/www to the resource path so static html can be loaded 
     # I'm pretty sure this puts the www/ folder from inst/ in the browser 


### PR DESCRIPTION
The error for violin plots was fixed by adding rlang as a dependency, and adding a library() call to the main app.