### PR TITLE
Update run_scExploreR.R

### DIFF
--- a/R/run_scExploreR.R
+++ b/R/run_scExploreR.R
@@ -1764,7 +1764,11 @@ run_scExploreR <-
       options = 
         list(
           "port" = 
-            if (!is.null(port)) port else getOption("shiny.port")
+            if (!is.null(port)) port else getOption("shiny.port"),
+           "host" = 
+            if (!is.null(host)) host else "127.0.0.1",
+           "launch.browser" = 
+            if (!is.null(launch.browser)) launch.browser else TRUE
         )
       )
   }


### PR DESCRIPTION
expose `host` and `launch.browser` options in `run_scExploreR()` for non-interactive use