### PR TITLE
Fix error in DGE tab

### DIFF
--- a/R/env_size.R
+++ b/R/env_size.R
@@ -36,7 +36,7 @@ env_size <- function(env,
   if (nrow(mem_df) > 0){
     bytes <- 
       mem_df |> 
-      select(size) |> 
+      dplyr::select(size) |> 
       sum()
     
     # Output size is in bytes. Divide to get size in other 

--- a/R/module-dge_tab.R
+++ b/R/module-dge_tab.R
@@ -769,7 +769,7 @@ dge_tab_server <- function(id,
                     # Explicitly coerce to tibble
                     as_tibble() %>%
                     # remove stat and auc from the output table
-                    select(-c(statistic, pval)) %>%
+                    dplyr::select(-c(statistic, pval)) %>%
                     # Using magrittr pipes here because the following
                     # statement doesn't work with base R pipes
                     # remove negative logFCs if box is checked


### PR DESCRIPTION
The error in #184 occurs within a select() function, which must be specified as dplyr::select(). This is corrected here, and all other select() functions in the app have been specified to use the dplyr package.