### PR TITLE
Include svglite package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     shinyWidgets (>= 0.6.2),
     sortable (>= 0.4.5),
     stringr,
+    svglite,
     tibble,
     viridisLite,
     waiter (>= 0.2.5),


### PR DESCRIPTION
The issue in #186 is likely caused by svglite not being included as a dependency. This has been corrected.