### PR TITLE
Correct 404 error with auto dictionary

### DIFF
--- a/inst/www/Auto_Dictionary.Rmd
+++ b/inst/www/Auto_Dictionary.Rmd
@@ -75,7 +75,7 @@ valid_features <- params$valid_features
 }
 ```
 
-Below is a summary of each metadata category in the current object. The ID of the category is shown in bold, and the data class (according to R) is shown beneath the ID.
+Below is a summary of each metadata category in the current object. This document is most useful as a guide for the advanced subsetting feature. The ID of the category is shown in bold, and the data class (according to R) is shown beneath the ID.
 
 Beneath the class, a summary of the metadata category is given. For categorical data types, unique values are displayed, and for numeric data types, summary statistics are shown. This summary is intended to give an overview of the range of values in each category, to aid in subsetting.
 


### PR DESCRIPTION
The 404 error (#213) was caused by specifying an improper path when creating the .Rmd for the object dictionary. The object dictionary was being created in a folder called "resources" in whatever directory the user was launching the app from, and this folder was not on the resource path. The link to the auto dictionary used "resources/", but for links this was not interpereted as "./resources"; instead it pointed to "inst/www" *in the package code* (this was set up via addResourcePath and works for loading CSS, JS, and the static html pages). Files that change based on the object can't be placed in the package directory.

The problem was solved by creating a new resource path, "session_files", pointing to a temp directory in the local file system of the server (created via tempdir()). The auto dictionary was rendered and saved to tempdir()/auto_dictionary_{session_id}.html, and the hyperlink to the file was set as "session_files/auto_dictionary_{session_id}.html".