### PR TITLE
Modfiy pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -39,6 +39,13 @@ jobs:
         run: install.packages("prettydoc")
         shell: Rscript {0}
 
+      # Some articles are written using SASS
+      # The sass package is installed to properly 
+      # render these articles.
+      - name: Install SASS package
+        run: install.packages("sass")
+        shell: Rscript {0}
+
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}


### PR DESCRIPTION
Add step to install the sass R package before creating the pkgdown website, to get vignettes that use SASS to render properly.