### PR TITLE
Add bslib installation to pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -46,6 +46,11 @@ jobs:
         run: install.packages("sass")
         shell: Rscript {0}
 
+      # Install bslib to render vignettes
+      - name: Install bslib
+        run: install.packages("bslib")
+        shell: Rscript {0}
+
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}


### PR DESCRIPTION
Added step to install bslib package, which adds Bootstrap 5 classes to Vignettes.