### PR TITLE
Render Dataset Setup Vignette "as-is"

### DIFF
--- a/vignettes/dataset_setup_walkthrough.Rmd
+++ b/vignettes/dataset_setup_walkthrough.Rmd
@@ -5,6 +5,8 @@ output:
     theme:
       bslib: true
       version: 5
+pkgdown:
+  as_is: true
 #date: "2023-11-16"
 ---
 


### PR DESCRIPTION
Pkgdown uses a special rendering engine when knitting vignettes, to integrate them with the pkgdown site format (https://rdrr.io/cran/pkgdown/man/build_articles.html).
The special rendering is disabled by adding as_is: true to the YAML header of the setup vignette.