### PR TITLE
263 object dictionary metadata description cards have blank headers when metadata labels are not defined in the config app

### DIFF
--- a/R/config_app_module-Options_Module.R
+++ b/R/config_app_module-Options_Module.R
@@ -157,7 +157,7 @@ options_ui <- function(id,
             if (!is.null(restore_inputs$hr)) {
               restore_inputs$hr
             } else {
-              ""
+              "" 
             }
           ),
         

--- a/R/config_app_module-Options_Module.R
+++ b/R/config_app_module-Options_Module.R
@@ -150,14 +150,14 @@ options_ui <- function(id,
         textInput(
           inputId = ns("hr"),
           label =
-            "Set label for metadata variable (will appear
+            "Set label for metadata variable(will appear
             as entered in app interface)",
           width = "380px",
           value =
             if (!is.null(restore_inputs$hr)) {
               restore_inputs$hr
             } else {
-              "" 
+             ""
             }
           ),
         
@@ -571,8 +571,8 @@ options_server <-
                 updateTextInput(
                   session,
                   inputId = "hr",
-                  # Value `label` section of config for variable
-                  value = config_individual$label
+                  # #Value `label` section of config for variable
+                     value = config_individual$label
                 )
                 
                 # Metadata variable description

--- a/R/config_app_module-Options_Module.R
+++ b/R/config_app_module-Options_Module.R
@@ -150,7 +150,7 @@ options_ui <- function(id,
         textInput(
           inputId = ns("hr"),
           label =
-            "Set label for metadata variable(will appear
+            "Set label for metadata variable (will appear
             as entered in app interface)",
           width = "380px",
           value =

--- a/inst/www/Auto_Dictionary.Rmd
+++ b/inst/www/Auto_Dictionary.Rmd
@@ -223,7 +223,7 @@ cards <-
       metadata_card(
         
         name = 
-             if(isTruthy(var$label)){
+             if (isTruthy(var$label)){
                var$label
              }else {
                var$meta_colname

--- a/inst/www/Auto_Dictionary.Rmd
+++ b/inst/www/Auto_Dictionary.Rmd
@@ -126,6 +126,12 @@ config <- params$config
       based on the background color */
     color: #FFFFFF !important;
 }
+
+.card-header{
+    background-color: inherit !important;
+    /* card header background color should inherit background color from card 
+    so that text is visible */
+}
 ```
 
 See below for details on the current dataset. These settings were determined by the user setting up this app instance. <!-- If contact info is defined, add the following: <<you may contact the user/group using the information below.>>-->

--- a/inst/www/Auto_Dictionary.Rmd
+++ b/inst/www/Auto_Dictionary.Rmd
@@ -221,7 +221,14 @@ cards <-
       
       # Individual card
       metadata_card(
-        name = var$label,
+        
+        name = 
+             if(isTruthy(var$label)){
+               var$label
+             }else {
+               var$meta_colname
+             },
+        
         description = var$description,
         # CSS class: assign bootstrap classes by
         class =


### PR DESCRIPTION
Fixes #263.