### PR TITLE
Allow same group by and split by selection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Remotes:
     github::amc-heme/SCUBA,
     github::amc-heme/scDE
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Depends: 
     R (>= 3.5.0)
 Suggests: 

--- a/R/FeaturePlotWrapper.R
+++ b/R/FeaturePlotWrapper.R
@@ -43,7 +43,7 @@
 #' startup and upon changing datasets.
 #' @param ... A list of arguments to pass to FeaturePlot
 #'
-#' @example
+#' @examples
 #' FeaturePlotSingle(
 #'      object = prim.mono, 
 #'      feature = "XIST", 

--- a/R/config_app_module-Options_Module.R
+++ b/R/config_app_module-Options_Module.R
@@ -9,7 +9,9 @@
 #' of the assay, metadata variable, or reduction represented by the current
 #' options card.
 #' @param object the Seurat object for which config settings are being defined.
-#' @param optcard_type
+#' @param optcard_type the type of options card to create. Currently, cards can 
+#' be created for "assays", "metadata", or "reductions", with a different UI 
+#' for each. 
 #' @param card_name the name of the current assay/metadata variable/reduction,
 #' etc., represented by the current options card. This defaults to the id.
 #' @param restore_inputs a list of input values, used for restoring inputs
@@ -286,8 +288,6 @@ options_ui <- function(id,
 #' the module applies to. This is the id by default, and can be changed.
 #' @param dev_mode When TRUE, additional logs are printed to the console while
 #' the app runs. Set using run_config_app().
-#'
-#' @return
 #'
 #' @noRd
 options_server <-

--- a/R/hr_name.R
+++ b/R/hr_name.R
@@ -8,7 +8,6 @@
 #' a prefix (for example, RNA features use the '_rna' key)
 #' @param assay_config the assays section of the config file, loaded in the 
 #' main app
-#' @param adt_threshold_key
 #' @param use_suffix if TRUE, add the human readable suffix defined in 
 #' assay_config in parentheses (for example, if the label is "Surface Protein",
 #' this will be added to the end of the title returned.)

--- a/R/module-plot_module.R
+++ b/R/module-plot_module.R
@@ -682,7 +682,7 @@ plot_module_ui <- function(id,
         
       ## Add/remove labels ####
       div( 
-        id = ns("label_div"),
+        id = ns("label_tooltip"),
         if (label_checkbox == TRUE){
           checkboxInput(
             inputId = ns("label"),
@@ -692,14 +692,15 @@ plot_module_ui <- function(id,
           )
         } else NULL
       ),
+      
       bsTooltip(
-        id = ns("label_div"), 
-        title = 
+        id = ns("label_tooltip"),
+        title =
           paste0("Label cells by metadata on plot. If checked, a menu will ",
                  "appear to select a variable for grouping cells. Labels will ",
                  "display in the center of each group in the chosen metadata ",
-                 "variable."), 
-        placement = "top", 
+                 "variable."),
+        placement = "top",
         trigger = "hover",
         options = NULL
       ),
@@ -2046,6 +2047,70 @@ plot_module_server <- function(id,
                    }
                  })
 
+                 ## 4.10. Disable label groups checkbox when group_by == split_by ####
+                 if (plot_type == "dimplot"){
+                   observe({
+                     req(plot_selections$group_by())
+                     req(plot_selections$split_by())
+                     
+                     if (plot_selections$group_by() == 
+                         plot_selections$split_by()){
+                       # Disable checkbox
+                       shinyjs::disable(
+                         id = "label"
+                         )
+                       
+                       # Change the tootip over the label checkbox
+                       # Remove existing tooptip, add a new one explaining why
+                       # the checkbox was disabled.
+                       # shinyBS::removeTooltip(
+                       #   session,
+                       #   id = ns("label_tooltip")
+                       #   )
+                       # shinyBS::addTooltip(
+                       #   session,
+                       #   id = ns("label_tooltip"),
+                       #   title = 
+                       #     paste0("Can't label cells when the group by and ",
+                       #            "split by selections are equal. To use ",
+                       #            "labels, please change either selection."),
+                       #   placement = "top", 
+                       #   trigger = "hover",
+                       #   options = NULL
+                       # )
+                     } else {
+                       shinyjs::enable(
+                         id = "label"
+                         )
+                       
+                       # Restore the default tooltip on the label checkbox
+                       # shinyBS::removeTooltip(
+                       #   session,
+                       #   id = ns("label_tooltip")
+                       #   )
+                       # shinyBS::addTooltip(
+                       #   session,
+                       #   id = ns("label_tooltip"),
+                       #   title = 
+                       #     paste0(
+                       #       "Label cells by metadata on plot. If checked, a ",
+                       #       "menu will appear to select a variable for ",
+                       #       "grouping cells. Labels will display in the ",
+                       #       "center of each group in the chosen metadata ",
+                       #       "variable."
+                       #     ), 
+                       #   placement = "top", 
+                       #   trigger = "hover",
+                       #   options = NULL
+                       #   )
+                       
+                       # Do not modify the value of the checkbox in other cases
+                       # (otherwise the checkbox would be set to TRUE each time
+                       # the user chages group_by and split_by)
+                     }
+                   })
+                 }
+                 
                  # 5. Process x-axis labels for dot plots----
                  if (plot_type == "dot"){
                    ## 5.1. Define default labels to show in menu ####
@@ -3489,7 +3554,13 @@ plot_module_server <- function(id,
                            object = object(),
                            group_by = plot_selections$group_by(),
                            split_by = plot_selections$split_by(),
-                           show_label = plot_selections$label(),
+                           show_label = 
+                             if (plot_selections$group_by() == 
+                                 plot_selections$split_by()){
+                               FALSE
+                             } else {
+                               plot_selections$label()
+                             },
                            show_legend = plot_selections$legend(),
                            ncol = plot_selections$ncol(),
                            is_subset = is_subset(),
@@ -3893,7 +3964,14 @@ plot_module_server <- function(id,
                      # Only runs when the plot is enabled
                      req(plot_switch())
 
-                     if (plot_type %in% c("dimplot", "violin", "proportion")){
+                     # Violin and proportion plots: plots behave very strangely
+                     # when the group by and split by variables are the same.
+                     # Instead of displaying the plots, an error message is 
+                     # shown. This used to also apply to DimPlots, but doing so
+                     # wasn't warrented, and the issues cause with DimPlots 
+                     # ended up being due to `label` being TRUE on plots with 
+                     # identical group by and split by selections (issue #309)
+                     if (plot_type %in% c("violin", "proportion")){
                        validate(
                          need(
                            input$group_by != input$split_by,
@@ -3907,11 +3985,11 @@ plot_module_server <- function(id,
                                # For cell type proportion plots, group by and
                                # split by are renamed "proportions" and
                                # "proportion comparison", respectively.
-                                 glue(
-                                   'Invalid selections for {plot_label}:
-                                   "Proportions" and "Proportion Comparison"
-                                   must be different.'
-                                   )
+                               glue(
+                                 'Invalid selections for {plot_label}:
+                                 "Proportions" and "Proportion Comparison"
+                                 must be different.'
+                                 )
                                }
                            )
                          )

--- a/R/module-subset_stats.R
+++ b/R/module-subset_stats.R
@@ -14,8 +14,6 @@
 #' @param gene_selected In the correlation tab, the gene selected by the user 
 #' for computation.
 #'
-#' @return
-#'
 #' @noRd
 subset_stats_ui <- function(id,
                             tab = c("dge", "corr"),
@@ -181,8 +179,6 @@ subset_stats_ui <- function(id,
 #' @param thresholding_present only used in the DGE tab. If TRUE, the number of cells above and below the chosen expression threshold will be displayed.
 #' @param dge_simple_threshold only used in the DGE tab. If thresholding is 
 #' being used, the value of the threshold chosen is passed here to be displayed.
-#'
-#' @return
 #'
 #' @noRd
 subset_stats_server <- 

--- a/man/assay_names.Rd
+++ b/man/assay_names.Rd
@@ -37,7 +37,7 @@ equivalent of assays, are returned.
 Anndata objects do not have an exclusive structure for modalities/assays.
 Additional modalities are stored in obsm, but this slot is not specific to
 modalities. To use assay_names with Anndata objects, a vector of assays
-(python list) must be stored in `object.uns["SCUBA_Assays"]`. This method
+(python list) must be stored in `object.uns["scExploreR_assays"]`. This method
 will return an error if this data is not present in the object.
 
 }}

--- a/man/reduction_names.Rd
+++ b/man/reduction_names.Rd
@@ -35,7 +35,7 @@ Returns the names of all reductions in a single-cell object.
 Anndata objects do not have an exclusive structure for reductions. Reductions
 are stored in obsm, but matrices that are not reductions may exist in this
 slot. To use reduction_names with Anndata objects, a vector of reductions
-(python list) must be stored in `object.uns["SCUBA_reductions"]`. This method
+(python list) must be stored in `object.uns["scExploreR_reductions"]`. This method
 will return an error if this data is not present in the object.
 
 }}


### PR DESCRIPTION
Fixes #309. When the group by and split by selections are the same, label is set to FALSE to avoid an error. The "label groups" checkbox was also disabled.