### PR TITLE
Fix #313

### DIFF
--- a/R/FeaturePlotWrapper.R
+++ b/R/FeaturePlotWrapper.R
@@ -191,7 +191,7 @@ FeaturePlotSingle<-
     }
   
   # If a split.by (metadata) column is defined, create a plot for each group 
-  ps <- list()
+  plots <- list()
   
   if (length(groups) > 1){
     # Fetch metadata table for referencing split_by groups
@@ -208,7 +208,7 @@ FeaturePlotSingle<-
       subset_indx <- meta_table[, split_by] == group
       subset_cells <- all_cells[subset_indx]
       
-      p <- 
+      plot <- 
         SCUBA::plot_feature(
           object, 
           features = feature, 
@@ -232,30 +232,30 @@ FeaturePlotSingle<-
         # If show_title is TRUE, use either default or custom titles
         if (is.null(custom_titles)){
           # custom_titles is NULL: use default behavior (group names)
-          p <-
-            p +
+          plot <-
+            plot +
             ggtitle(group)
         } else {
           # custom_titles is not NULL: use custom titles 
           # (custom titles should be a character vector)
-          p <-
-            p +
+          plot <-
+            plot +
             ggtitle(custom_titles[i])
         }
       } else {
         # If show_title is FALSE, remove titles
-        p <-
-          p +
+        plot <-
+          plot +
           ggtitle(NULL)
       }
 
-      ps[[group]] <- p
+      plots[[group]] <- plot
       
     }
     
     plot <- 
       wrap_plots(
-        ps, 
+        plots, 
         ncol = ncol, 
         guides = "collect"
         ) 
@@ -300,7 +300,7 @@ FeaturePlotSingle<-
     # Metadata column is not defined:
     # If only one group or if split_by is undefined, create one plot 
     # for the object provided.
-    p <- 
+    plot <- 
       suppressMessages(
         SCUBA::plot_feature(
           object, 
@@ -332,8 +332,8 @@ FeaturePlotSingle<-
       if (is.null(custom_titles)){
         # custom_titles is NULL: use default behavior
         # Default behavior for single-group plots: use feature title
-        p <-
-          p +
+        plot <-
+          plot +
           ggtitle(
             hr_name(
               machine_readable_name = feature,
@@ -343,14 +343,14 @@ FeaturePlotSingle<-
       } else {
         # custom_titles is not NULL: use custom titles
         # Custom titles should be a single-element character vector in this case
-        p <-
-          p +
+        plot <-
+          plot +
           ggtitle(custom_titles)
       }
     } else {
       # If show_title is FALSE, remove titles
-      p <-
-        p +
+      plot <-
+        plot +
         ggtitle(NULL)
     }
     
@@ -358,14 +358,14 @@ FeaturePlotSingle<-
     
     
     # Apply title theme  
-    p <-
-      p +
+    plot <-
+      plot +
       theme(
         plot.title = 
           element_text(size = 14, face = "bold")
       )
     
-    return(p)
+    return(plot)
       
   }
   
@@ -535,7 +535,7 @@ MultiFeatureSimple <-
     }
     
     # Create one plot for each group (feature)
-    ps <- list()
+    plots <- list()
     
     # 3. Determine legend limits -----------------------------------------------
     # If scales are the same across plots, gather unified legend limits
@@ -609,7 +609,7 @@ MultiFeatureSimple <-
         } 
       
       # 4.2. Create plot 
-      p <- 
+      plot <- 
         SCUBA::plot_feature(
           object, 
           features = group, 
@@ -630,8 +630,8 @@ MultiFeatureSimple <-
       # Legend scale: applied to each plot in all cases (as opposed to being
       # applied to all plots after Patchwork object is created)
       suppressMessages(
-        p <-
-          p +
+        plot <-
+          plot +
           scale_color_gradientn(
             plot_legend_title, 
             # colors: use `colors` argument, or the ith color of the 
@@ -655,8 +655,8 @@ MultiFeatureSimple <-
         # If show_title is TRUE, use either default or custom titles
         if (is.null(custom_titles)){
           # custom_titles is NULL: use default behavior (group names)
-          p <-
-            p +
+          plot <-
+            plot +
             ggtitle(
               # Remove assay key from feature name
               hr_name(
@@ -668,23 +668,23 @@ MultiFeatureSimple <-
         } else {
           # custom_titles is not NULL: use custom titles 
           # (custom titles should be a character vector)
-          p <-
-            p +
+          plot <-
+            plot +
             ggtitle(custom_titles[i])
         }
       } else {
         # If show_title is FALSE, remove titles
-        p <-
-          p +
+        plot <-
+          plot +
           ggtitle(NULL)
       }
       
-      ps[[group]] <- p
+      plots[[group]] <- plot
     }
     
     plot <- 
       wrap_plots(
-        ps, 
+        plots, 
         ncol = ncol, 
         # `guides`:
         # collect: gather scales from all plots. 

--- a/R/module-plot_module.R
+++ b/R/module-plot_module.R
@@ -1508,7 +1508,7 @@ plot_module_server <- function(id,
                          # Only continue if menu_type is not NULL (when custom
                          # titles is selected)
                          req(menu_type())
-
+                         
                          if (input$title_settings == "custom"){
                            # Determine current menu structure
                            if (menu_type() == "single"){
@@ -1522,25 +1522,56 @@ plot_module_server <- function(id,
                              custom_vector()
                            }
                          } else {
-                           # Otherwise, define a default title based on the 
-                           # features entered, and whether the user requests to 
-                           # show the modality key in front of features instead
-                           # of the suffix defined in the config file.
-                           if (raw_feature_names() == FALSE){
-                             sapply(
-                               features_entered(),
-                               function(feature, assay_config){
-                                 hr_name(
-                                   machine_readable_name = feature, 
-                                   assay_config = assay_config,
-                                   use_suffix = TRUE
-                                 )
-                               },
-                               assay_config()
-                             )
+                           # If custom titles is FALSE, additional logic is 
+                           # used to set a default title. If the title involves
+                           # the names of features entered, additional 
+                           # transformations are involved.
+                           
+                           # Determine if the default title involves the use
+                           # of feature names. feature_based_title is used to 
+                           # determine operations to peform based on the 
+                           # results of the previous conditionals
+                           if (plot_type == "feature"){
+                             if (plot_selections$split_by() != "none"){
+                               # When split_by is enabled, the title is based 
+                               # on the split by groups, not the feature name
+                               feature_based_title <- FALSE
                              } else {
-                             features_entered()
+                               # Otherwise, the title is based on the feature
+                               # name
+                               feature_based_title <- TRUE
                              }
+                           } else {
+                             feature_based_title <- TRUE
+                           }
+                           
+                           # For defaults that involve the use of feature 
+                           # names, the assay keys will be removed. In other
+                           # cases, NULL is returned, which will prompt 
+                           # plotting functions to use their defaults.
+                           if (feature_based_title == TRUE){
+                             if (raw_feature_names() == FALSE){
+                               # For feature based default titles, the 
+                               # feature names are modified to remove the 
+                               # assay key, unless the "raw" feature names 
+                               # checkbox is TRUE.
+                               sapply(
+                                 features_entered(),
+                                 function(feature, assay_config){
+                                   hr_name(
+                                     machine_readable_name = feature,
+                                     assay_config = assay_config,
+                                     use_suffix = TRUE
+                                   )
+                                 },
+                                 assay_config()
+                               )
+                               } else {
+                               features_entered()
+                               }
+                           } else {
+                             NULL
+                           }
                            }
                        })
                    }
@@ -3638,6 +3669,7 @@ plot_module_server <- function(id,
                            object = object(),
                            features_entered = features(),
                            assay_config = assay_config(),
+                           raw_feature_names = raw_feature_names(),
                            # Group by: influences label placement
                            group_by = plot_selections$group_by(),
                            split_by = plot_selections$split_by(),

--- a/R/shiny_feature.R
+++ b/R/shiny_feature.R
@@ -161,7 +161,7 @@ shiny_feature <- function(object,
       # For the plotting package, we should consider setting the super_title to
       # a value instead of TRUE/FALSE, so the overall title can be modified.
       if (raw_feature_names == FALSE){
-        feature_title <-
+        feature_display_name <-
           hr_name(
             machine_readable_name = features_entered,
             assay_config = assay_config,
@@ -171,7 +171,7 @@ shiny_feature <- function(object,
         feature_plot <-
           feature_plot +
           plot_annotation(
-            title = feature_title
+            title = feature_display_name
             )
       } else {
         # Do nothing if raw_feature_names is TRUE
@@ -241,7 +241,7 @@ shiny_feature <- function(object,
           # Reduction: uses the input for reduction if it exists, otherwise
           # it is set to NULL and will use default settings.
           reduction = if (!is.null(reduction)) reduction else NULL
-        )
+          )
       
       #+
       # Clean up title: this changes the feature names on each plot
@@ -349,7 +349,7 @@ shiny_feature <- function(object,
     # There is no legend on blended feature plots, so legend position element 
     # is not shown
     
-    # A. Axis limits: use limits from full dataset if specified.
+    ## A. Axis limits: use limits from full dataset if specified. ####
     # Test if subset is present and if the corresponding original_limits 
     # reactive is truthy (i.e. both present and checked).
     if (is_subset & isTruthy(original_limits)){
@@ -362,7 +362,7 @@ shiny_feature <- function(object,
         )
     }
     
-    # B. split plot Layout: 2x2 or the Seurat default (4 column layout)
+    ## B. split plot Layout: 2x2 or the Seurat default (4 column layout) ####
     if (isTruthy(blend_layout)){
       if (blend_layout == "2col"){
         # Design: bounds of first three panels and legend
@@ -376,17 +376,46 @@ shiny_feature <- function(object,
       # For a four column layout, no change is necessary.
     }
     
-    # C. Default titles for blended feature plots
+    ## C. Default titles for blended feature plots ####
+    # Feature title formula for the four facets created: 
+    # first feature, second feature, "coexpression", and "coexpression scale"
+    
+    # Form display names for features based on whether 
+    # raw_feature_names is selected
+    # feature_display_names <-
+    #   if (raw_feature_names == FALSE){
+    #     
+    #   } else {
+    #     features_entered
+    #   }
+    
+    feature_display_names <-
+      sapply(
+        1:length(features_entered),
+        function(i){
+          if (raw_feature_names == FALSE){
+            hr_name(
+              machine_readable_name =
+                features_entered[i],
+              assay_config = assay_config,
+              # Use the assay label if provided in
+              # config app
+              use_suffix = TRUE
+            )
+          } else {
+            features_entered[i]
+          }
+        }
+      )
+    
+    # Apply titles 
     for (i in 1:4){
       if (i < 3){
         # Panel 1, 2: features entered (human-readable name)
         feature_plot[[i]] <-
           feature_plot[[i]] +
           ggtitle(
-            hr_name(
-              features_entered[i],
-              assay_config = assay_config
-            )
+            feature_display_names[i]
           )
       } else if (i == 3){
         # Panel 3: blend panel
@@ -401,18 +430,10 @@ shiny_feature <- function(object,
           ggtitle("Coexpression Scale") +
           labs(subtitle = "(Blend threshold: 0.5)") +
           xlab(
-            hr_name(
-              features_entered[1],
-              assay_config = assay_config,
-              use_suffix = FALSE
-              )
+            feature_display_names[1]
             ) +
           ylab(
-            hr_name(
-              features_entered[2],
-              assay_config = assay_config,
-              use_suffix = FALSE
-            )
+            feature_display_names[2]
           ) +
           theme(
             plot.title = 

--- a/R/shiny_feature.R
+++ b/R/shiny_feature.R
@@ -9,6 +9,11 @@
 #' @param assay_config the assays section of the config file, loaded at app 
 #' startup and upon changing datasets.
 #' @param split_by user-specified metadata variable for splitting plots.
+#' @param raw_feature_names a reactive variable indicating whether to remove 
+#' the modality key in the config file from feature names. When FALSE, the 
+#' modality key is removed, and when TRUE, it is retained. For example, a 
+#' feature from an assay/modality named "protein" will display as "protein_CD4" 
+#' instead of "CD4 (Surface Protein)" when raw_feature_names is TRUE.
 #' @param group_by the metadata column to use for showing labels on the plot, 
 #' if labels are enabled.
 #' @param blend Whether to use blended feature plots for feature co-expression. 
@@ -56,6 +61,7 @@ shiny_feature <- function(object,
                           features_entered, 
                           assay_config, 
                           split_by, 
+                          raw_feature_names,
                           group_by = NULL,
                           blend = FALSE, 
                           order = FALSE, 
@@ -107,47 +113,86 @@ shiny_feature <- function(object,
   )
   
   if (length(features_entered) == 1){
-    # Use FeaturePlotSingle.R for single-feature plots
-    FeaturePlotSingle(
-      object,
-      feature = features_entered,
-      split_by = if (split_by != "none") split_by else NULL,
-      # Labels for groups: passed to plot_feature
-      label_by = group_by,
-      # Colors: set to colors passed in the palette. 
-      # If NULL, Seurat defaults are used
-      colors = if (!is.null(palette)) palette,
-      show_title = show_title,
-      # Use custom titles if defined
-      custom_titles = if (!is.null(custom_titles)) custom_titles else NULL,
-      legend_title = legend_title,
-      super_title = super_title,
-      ncol = ncol,
-      reduction = 
-        if (!is.null(reduction)) reduction else NULL,
-      xlim = 
-        if (isTruthy(original_limits)){
-          xlim_orig
-        } else NULL,
-      ylim = 
-        if (isTruthy(original_limits)){
-          ylim_orig
-        } else NULL,
-      show_legend = show_legend,
-      # `...` arguments passed to plot_feature
-      label = show_label,
-      order = order,
-      assay_config = assay_config
-      )
+    # Single-feature plots ####
+    # Use FeaturePlotSingle.R 
+    print("Super title value")
+    print(super_title)
+    
+    feature_plot <-
+      FeaturePlotSingle(
+        object,
+        feature = features_entered,
+        split_by = if (split_by != "none") split_by else NULL,
+        # Labels for groups: passed to plot_feature
+        label_by = group_by,
+        # Colors: set to colors passed in the palette. 
+        # If NULL, Seurat defaults are used
+        colors = if (!is.null(palette)) palette,
+        show_title = show_title,
+        # Use custom titles if defined
+        custom_titles = if (!is.null(custom_titles)) custom_titles else NULL,
+        legend_title = legend_title,
+        super_title = super_title,
+        ncol = ncol,
+        reduction = 
+          if (!is.null(reduction)) reduction else NULL,
+        xlim = 
+          if (isTruthy(original_limits)){
+            xlim_orig
+          } else NULL,
+        ylim = 
+          if (isTruthy(original_limits)){
+            ylim_orig
+          } else NULL,
+        show_legend = show_legend,
+        # `...` arguments passed to plot_feature
+        label = show_label,
+        order = order,
+        assay_config = assay_config
+        )
+    
+    # scExplorer-specific modification of ggtitle for single feature plots
+    # with a split-by variable 
+    # *** DO NOT MOVE THIS TO scPLOTS ***
+    if (split_by != "none" & super_title == TRUE){
+      # In the case where a split-by variable is defined, custom_titles modifies
+      # the facet labels for the split-by levels, not the overall title with the
+      # feature name (super_title). If displayed, the overall title is currently 
+      # always set to the "raw" feature name with the modality key. The modality 
+      # key must be removed if raw_feature_names is FALSE.
+      
+      # For the plotting package, we should consider setting the super_title to
+      # a value instead of TRUE/FALSE, so the overall title can be modified.
+      if (raw_feature_names == FALSE){
+        feature_title <-
+          hr_name(
+            machine_readable_name = features_entered,
+            assay_config = assay_config,
+            use_suffix = TRUE
+            )
+        
+        feature_plot <-
+          feature_plot +
+          plot_annotation(
+            title = feature_title
+            )
+      } else {
+        # Do nothing if raw_feature_names is TRUE
+      }
+    }
+    
+    # Return single-feature feature plot
+    feature_plot
   } else if (
-    # Multi-feature plots without blend enabled
+    # Multi-feature plots ####
+    # (when there are multiple features, or 2 with blend not enabled)
     (length(features_entered) == 2 & !isTruthy(blend))|
     (length(features_entered) > 2)
-    ) {
+    ){
     # Function used for plot depends on split_by choice
     if (split_by == "none"){
-      # Use feature plot wrapper for multiple feature plots with 
-      # no split_by category 
+      ## Multi-feature plots, no split by variable ####
+      # Use MultiFeatureSimple from featurePlotWrapper.R
       MultiFeatureSimple(
         object,
         features = features_entered,
@@ -179,7 +224,8 @@ shiny_feature <- function(object,
         assay_config = assay_config
       )
     } else {
-      # If a split_by category is defined, use Seurat FeaturePlot function
+      ## Multi-feature plots, with split_by variable ####
+      # Use FeaturePlot function (SCUBA/scPlots)
       feature_plot <-
         SCUBA::plot_feature(
           # Object or subset
@@ -197,7 +243,7 @@ shiny_feature <- function(object,
           label = show_label,
           # Reduction: uses the input for reduction if it exists, otherwise
           # it is set to NULL and will use default settings.
-          reduction = if(!is.null(reduction)) reduction else NULL
+          reduction = if (!is.null(reduction)) reduction else NULL
         )
       
       #+
@@ -268,7 +314,7 @@ shiny_feature <- function(object,
       feature_plot
     }
   } else if (length(features_entered) == 2 & isTruthy(blend)){
-    # Blended feature plot
+    # Blended feature plot ####
     
     # Palette for blending: fill to red and blue if NULL
     # "lightgrey" is the Seurat default color used when neither feature is expressed 

--- a/R/shiny_feature.R
+++ b/R/shiny_feature.R
@@ -115,9 +115,6 @@ shiny_feature <- function(object,
   if (length(features_entered) == 1){
     # Single-feature plots ####
     # Use FeaturePlotSingle.R 
-    print("Super title value")
-    print(super_title)
-    
     feature_plot <-
       FeaturePlotSingle(
         object,


### PR DESCRIPTION
The cause of #313 is the `variable_length_custom_title()` reactive expression in the plot module. The reactive expression returns either a title value to use on plots (via the `custom_title` parameter of the `shiny_feature` or `shiny_ridge` plotting functions), or `NULL`, which directs the plotting functions to use defaults. Originally, the expression returned `NULL` whenever the title settings menu was equal to anything besides "custom".

When the changes in #305 were introduced, a toggle to display a "raw" feature name without the modality key vs. one with the key was added. The feature name displayed on plots needed to change based on whether raw feature names were selected, and this was no longer covered by the defaults of the downstream plotting functions. Code was added to  `variable_length_custom_title()` to return a title value to use instead of `NULL`, but this caused an issue in the case of feature plots with a split by selection. When a split_by variable is defined, the titles used in the plotting function are based on the groups in the split_by variable, not the names of the features entered, and `variable_length_custom_title()` was setting the titles based on the feature names in this case, causing #313. 

To fix the issue, `variable_length_custom_title()` was modified to return title values based on whether the title depends on a feature name, or on something else. The `feature_based_title` variable was created and conditionally set to `TRUE` or `FALSE` based on the state of the split_by selection. When `TRUE`, `variable_length_custom_title()` returns feature names with the modality keys removed or kept based on whether "raw features" are enabled, and when `FALSE`, `NULL` is returned, directing `plot_feature` to use default title values. The default values properly cover the names of the split_by groups as they appear, so returning NULL instead of the groups is fine in this case. There are no other known cases involving `variable_length_custom_title()` where the titles are based on anything other than feature names, so there should not be any additional issues introduced by this change.

During manual testing of this PR, the titles on split feature plots were found to not respond to the value of the raw feature display checkbox. It was also found that the title shown above single-feature plots with a split by selection (the `super_title`) did not respond to the raw features checkbox. Neither of these cases are currently handled by the `custom_titles` parameter of `shiny_feature`, and therefore not by the upstream `variable_length_custom_title()`, so changes to address these were made outside of `variable_length_custom_title()`. For both cases, the setting for raw feature display was passed to `shiny_feature`, and the code in `shiny_feature` used to set the titles in both cases was modified to use titles with or without the modality key based on the value of the raw feature names selection. 

