### PR TITLE
Add object guidelines vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Remotes:
     github::amc-heme/SCUBA,
     github::amc-heme/scDE
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends: 
     R (>= 3.5.0)
 Suggests: 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -28,7 +28,7 @@ navbar:
         href: articles/dataset_setup_walkthrough.html
       - text: Exploring your Data
         href: articles/tutorial.html
-      - text: Preparing Objects for scExploreR
+      - text: Object Preparation Guidelines
         href: articles/object_guidelines.html
       - text: -------
       - text: "Additional Information"
@@ -38,7 +38,7 @@ navbar:
         href: articles/advanced_subsetting_documentation.html
       - text: -------
       - text: "Full Documentation"
-      - text: Full App Documentation
+      - text: scExploreR Documentation
         href: articles/full_documentation.html
       - text: Config App Documentation
         href: articles/config_documentation.html

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,13 +30,15 @@ navbar:
         href: articles/tutorial.html
       - text: Preparing Objects for scExploreR
         href: articles/object_guidelines.html
+      - text: -------
+      - text: "Additional Information"
       - text: Guide to scRNA-Seq Plots
         href: articles/scRNA_Plots_Explained.html
       - text: String Subsetting Guide
         href: articles/advanced_subsetting_documentation.html
       - text: -------
-      - text: "Reference"
-      - text: Full App Manual
+      - text: "Full Documentation"
+      - text: Full App Documentation
         href: articles/full_documentation.html
       - text: Config App Documentation
         href: articles/config_documentation.html

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -28,6 +28,8 @@ navbar:
         href: articles/dataset_setup_walkthrough.html
       - text: Exploring your Data
         href: articles/tutorial.html
+      - text: Preparing Objects for scExploreR
+        href: articles/object_guidelines.html
       - text: Guide to scRNA-Seq Plots
         href: articles/scRNA_Plots_Explained.html
       - text: String Subsetting Guide

--- a/vignettes/advanced_subsetting_documentation.Rmd
+++ b/vignettes/advanced_subsetting_documentation.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "How to Use String Subseting"
+title: "String Subsetting Guide"
 output:
   html_document:
     toc: true

--- a/vignettes/config_documentation.Rmd
+++ b/vignettes/config_documentation.Rmd
@@ -170,7 +170,9 @@ download_button <-
   }
 ```
 
-The scExploreR config app is used to configure datasets for display in the main browser. This vignette will walk through the operation of the app and detail all settings that may be adjusted.
+The scExploreR config app is used to configure single-cell objects for display in the main browser. This vignette will walk through the operation of the app and detail all settings that may be adjusted.
+
+For guidelines on preparing objects before loading them into the config app, see the [object guidelines vignette](object_guidelines.html), and see the [app setup walkthrough vignette](dataset_setup_walkthrough.html) for an interactive walkthrough of both object preparation and use of the config app.
 
 # Running the config app
 

--- a/vignettes/config_documentation.Rmd
+++ b/vignettes/config_documentation.Rmd
@@ -239,7 +239,7 @@ On the upper right-hand corner of the screen, a panel of general assay-related o
 ```
 #### *"*Choose Genes Assay"
 
-The assay selected in this tab will be the assay used when computing differential expression or correlation; it does not effect plotting.
+The assay selected in this menu will be the assay used when computing differential expression. <!--or correlation;--> It does not effect plotting.
 
 Note, if you wish to include only non-gene assays in the object, you may designate those assays as the "genes" assay, but this may cause issues with the DGE and correlation analyses. The analyses are validated for gene expression only, and may not be accurate when using other data types. We will address means of including these data types in analyses in the future.
 

--- a/vignettes/dataset_setup_walkthrough.Rmd
+++ b/vignettes/dataset_setup_walkthrough.Rmd
@@ -690,7 +690,7 @@ There are no alternate modalities in `obsm`. The reductions in `obsm` are the sa
 
 Now that we have identified metadata, reductions, and modalities to include for the dataset, the next step is to apply these settings in the config app.
 
-## Anndata-specific Preparation for the Config App
+## Anndata-specific Preparation for the Config App {#anndata_uns_requirements}
 
 Before loading anndata objects into the config app, the keys of alternate modalities and reductions must be defined, since both types of data are stored in `obsm`, and there is no exclusive storage slot for reductions or modalities in anndata objects.
 

--- a/vignettes/dataset_setup_walkthrough.Rmd
+++ b/vignettes/dataset_setup_walkthrough.Rmd
@@ -692,7 +692,7 @@ Now that we have identified metadata, reductions, and modalities to include for 
 
 ## Anndata-specific Preparation for the Config App
 
-Before loading Anndata objects into the config app, the keys of alternate modalities and reductions must be defined, since both types of data are stored in `obsm`, and there is no exclusive storage slot for reductions or modalities in anndata objects.
+Before loading anndata objects into the config app, the keys of alternate modalities and reductions must be defined, since both types of data are stored in `obsm`, and there is no exclusive storage slot for reductions or modalities in anndata objects.
 
 Alternate modalities and reductions should be stored in `uns`, under `scExploreR_assays` and `scExploreR_reductions`, respectively. This is done below in python, via reticulate, for both the full object and the SCLC object.
 

--- a/vignettes/dataset_setup_walkthrough.Rmd
+++ b/vignettes/dataset_setup_walkthrough.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Hosting a Dataset in scExploreR and Performing Analysis"
+title: "App Setup Walkthrough"
 output: 
   html_document:
     theme:

--- a/vignettes/full_documentation.Rmd
+++ b/vignettes/full_documentation.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "scExploreR Manual"
+title: "scExploreR Documentation"
 output: 
   html_document:
     toc: true

--- a/vignettes/full_documentation.Rmd
+++ b/vignettes/full_documentation.Rmd
@@ -511,9 +511,10 @@ If either of the percent expression values are very low, or if there is a large 
 
 To visually identify and verify the groups/marker classes being compared in the selected test, a dimensional reduction plot will display beneath the table. After the plot is displayed, a menu ("DimPlot options") will appear in the options panel on the left. The reduction and the color by metadata can be changed here.
 
+<!-- The correlations tab was removed due to performance issues. The docs for the tab are left here but commented out.
 # Correlations Tab {#correlations-tab}
 
-This tab is used to compute the correlation between a gene entered and all other genes in the dataaset. The correlations analysis uses a pearson correlation coefficient. Only genes may be used for computing correlation at this time: other feature types will be available in the future.
+This tab is used to compute the correlation between a gene entered and all other genes in the dataset. The correlations analysis uses a pearson correlation coefficient. Only genes may be used for computing correlation at this time: other feature types will be available in the future.
 
 ## Running a correlation analysis
 
@@ -536,6 +537,7 @@ The columns of the correlation table are as below. The table may be downloaded v
 ### Correlation Scatterplots
 
 Click any gene on the correlation table to view a scatterplot of expression for the gene entered vs. the selected gene (for more information on scatterplots, see the [scatterplots](#scatterplots) section). If a subset is selected, two plots will display, one for the full data and the other for the selected subset. The metadata variable used for coloring the plot may be selected using the **"choose metadata to group by"** menu. To download either of the plots, press the "`r icon("poll")` download scatterplot" button corresponding to the desired plot.
+-->
 
 # Changing Datasets
 

--- a/vignettes/full_documentation.Rmd
+++ b/vignettes/full_documentation.Rmd
@@ -90,7 +90,7 @@ At the top of the options panel you will see several switches, one for each plot
 
 -   **Dot Plot:** shows the average scaled value and percentage of cells with non-zero values for multiple features across groups of cells as defined by metadata categories.
 
--   **Scatterplot:** compares values of two features. Correlation between values may be quantified in the [Gene Correlations Tab](#correlations-tab).
+-   **Scatterplot:** compares values of two features. <!--Correlation between values may be quantified in the [Gene Correlations Tab](#correlations-tab).-->
 
 -   **Ridge Plot:** displays a density plot of a feature's value across a group of cells defined by metadata.
 
@@ -139,7 +139,7 @@ This menu is used to select a categorical metadata variable (e.g. cell type) to 
 
 This menu sets a categorical metadata variable used to "split" cells into separate plots for viewing side-by-side, and defaults to "None".
 
-This menu is useful for comparing projections between different metadata values. For example, broad differences in cell type proportions may be visualized when splitting by disease response. These obsservations can be analyzed in more detail in the differential gene expression and correlations tabs. 
+This menu is useful for comparing projections between different metadata values. For example, broad differences in cell type proportions may be visualized when splitting by disease response. These obsservations can be analyzed in more detail in the differential gene expression tab. <!-- and correlations tabs.--> 
 
 When a variable is selected, a slider to choose the number of columns will appear under the "Title options menu" (see [Choose number of columns](#choose-number-of-columns) for more info).
 
@@ -306,7 +306,7 @@ download_button(plot_type = "Dot Plot")
 
 ## Scatterplots {#scatterplots}
 
-Scatterplots are useful for viewing co-expression of two features. All cells are plotted according to the expression of each feature, and are useful for quallitative assessments of correlation.
+Scatterplots are useful for viewing co-expression of two features. All cells are plotted according to the expression of each feature, and are useful for qualitative assessments of correlation.
 
 ### Feature for x-axis
 

--- a/vignettes/object_guidelines.Rmd
+++ b/vignettes/object_guidelines.Rmd
@@ -1,0 +1,394 @@
+---
+title: "Guidelines for Preparing objects for scExploreR"
+output: 
+  html_document:
+    theme:
+      bslib: true
+      version: 5
+#date: "2023-11-16"
+---
+
+```{scss document_css, echo = FALSE}
+/* Centers text and block elements */
+.center{
+  text-align: center;
+  /* Display must be set to block for centering to work */
+  display: block;
+  }
+
+.white-text{
+  color: white;
+}
+
+/* Bootstrap card elements */
+.card-header{
+  background-color: #CFB87C;
+  /* Adds a mrgin-top of 0 to the existing bootstrap class to remove white space
+   that appears when using the card component in an Rmd */
+  margin-top: 0px;
+}
+
+.card-body{
+  background-color: #E1E1E1; 
+  /* The border radius property is not properly inherited from the parent .card
+    element. The reason is unkown, but explicitly defining it here fixes 
+    the issue */
+  border-radius: 0px 0px var(--bs-card-border-radius) var(--bs-card-border-radius);
+}
+
+/* CSS for callouts
+   From https://codepen.io/superjaberwocky/pen/rLKxOa */
+   /* Requires SASS to be enabled, with sass package and "scss" code chunk*/
+.callout {
+  padding: 20px;
+  margin: 20px 0;
+  border: 1px solid #eee;
+  /* If the border-radius is greater than border-left-width,  
+     the left border will curve inward onto the element's body,
+     creating a cresent-like shape*/
+  border-left-width: 8px;
+  border-radius: 8px;
+  h4, h5 {
+    margin-top: 0;
+    margin-bottom: 5px;
+  }
+  p:last-child {
+    margin-bottom: 0;
+  }
+  code {
+    border-radius: 3px;
+  }
+  & + .bs-callout {
+    margin-top: -5px;
+  }
+}
+
+/* Define properties for default, primary, info, etc. classes*/
+@each $name,$color in 
+  (default,#777),
+  (primary,#428bca),
+  (success,#5cb85c),
+  (danger,#d9534f),
+  (warning,#f0ad4e),
+  (info,#5bc0de), 
+  (bdc,#29527a){
+  .callout-#{$name} {
+    border-left-color: $color;
+    /* Background: color above, with an alpha hex value of '35'*/
+    background-color: #{$color + '35'};
+    h4, h5 {
+      color: $color;
+    }
+  }
+}
+
+/* Applied to output of code chunks. Causes a scrollbar to appear 
+   when the output extends beyond the max-height. */
+/* Adapted from https://bookdown.org/yihui/rmarkdown-cookbook/html-scroll.html */
+/* Classes are defined for several max heights */
+@each $height in 
+  80,
+  100,
+  300{
+  .scroll-#{$height} {
+    max-height: #{$height + "px"};
+    overflow-y: auto;
+    background-color: inherit;
+  }
+}
+
+/* For the object table, override the background colors applied
+   by R Markdown using the object-table class*/
+.object-table th,
+.object-table td{
+  background-color: transparent !important;
+  padding: 5px 15px;
+}
+
+.object-table table{
+  background-color: transparent !important;
+}
+
+/* Also add a bottom border underneath the table header */
+.object-table .header{
+  border-style: solid;
+  border-width: 0px 0px 2px 0px;
+}
+
+/* Color of icons in object table indicating presence and absence of features */
+.yes {
+  color: #008b00;
+}
+
+.no {
+  color: #8b0000;
+}
+
+/* Classes to control size of text */
+.x-large{
+  font-size: 1.3em;
+}
+
+.small{
+ font-size: 0.9em;
+}
+```
+
+```{r message=FALSE, warning = FALSE, echo=FALSE}
+# Load shiny library to render icons in object table
+library(shiny)
+library(htmltools)
+```
+
+This vignette details the requirements and guidelines for loading single-cell data in scExploreR. 
+
+# What objects can I upload to scExploreR?
+
+scExploreR works with many common object formats for single-cell data. Functionality is largely similar between object classes, but there are some differences. A table with the supported object classes summarizing the differences in functionality between each class is given below.
+
+```{r object_functionality_table, echo=FALSE, message=FALSE, warning=FALSE}
+# Functionality by object class table
+# Icon functions: render icons indicating whether or not a feature is present
+# for the obhect classs
+yes <- 
+  function(){
+    shiny::icon(
+      name = "check-circle",
+      class = "yes fas center x-large"
+      )
+  }
+
+no <-
+  function(){
+    shiny::icon(
+      name = "minus-circle", #circle-xmark
+      class = "no fas center x-large"
+      )
+    }
+
+tags$div(
+  class = "object-table",
+  tags$table(
+    # Initialize table columns
+    tags$colgroup(
+      tags$col(class = "col-md-4", span = 1),
+      tags$col(class = "col-md-2", span = 1),
+      tags$col(class = "col-md-2", span = 1),
+      tags$col(class = "col-md-2", span = 1),
+      tags$col(class = "col-md-2", span = 1)
+      ),
+    # Table header
+    tags$thead(
+      # Header class inserts a border beneath the header
+      class = "header",
+      tags$tr(
+        # First column is blank
+        tags$th(),
+        tags$th(tags$b("Seurat", class = "center")),
+        tags$th(tags$b("Seurat v5 + BPCells", class = "center")),
+        tags$th(tags$b("SingleCellExperiment", class = "center")),
+        tags$th(tags$b("Anndata", class = "center"))
+        )
+      ),
+    # Main table
+    tags$tbody(
+      # Header row for plotting features
+      tags$tr(
+        # "Plotting" is a section header, so it is bold and no data is shown
+        # in the other columns
+        tags$td(
+          tags$b(
+            "Plotting"
+            )
+          ),
+        tags$td(),
+        tags$td(),
+        tags$td(),
+        tags$td()
+        ),
+      # icon functions yes() and no() used to indicate the presence or abscence
+      # of features
+      tags$tr(
+        tags$td("Full plotting capabilities"),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(yes())
+        ),
+      tags$tr(
+        tags$td("Consistent Style"),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(yes())
+        ),
+      # Section header for Subsetting
+      tags$tr(
+        tags$td(
+          tags$b(
+            "Subsetting"
+            )
+          ),
+        tags$td(),
+        tags$td(),
+        tags$td(),
+        tags$td()
+        ),
+      tags$tr(
+        tags$td("Based on categorical Metadata"),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(yes())
+        ),
+      tags$tr(
+        tags$td("Based on feature expression"),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(no()),
+        tags$td(yes())
+        ),
+      tags$tr(
+        tags$td("Advanced code-based subsetting"),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(no()),
+        tags$td(no())
+        ),
+      # Section header for DGE features
+      tags$tr(
+        tags$td(
+          tags$b(
+            "Differential Gene Expression"
+            )
+          ),
+        tags$td(),
+        tags$td(),
+        tags$td(),
+        tags$td()
+        ),
+      tags$tr(
+        tags$td("Can perform DGE"),
+        tags$td(yes()),
+        tags$td(yes()),
+        tags$td(no()),
+        tags$td(yes())
+        ),
+      tags$tr(
+        tags$td("Results show AUC value"),
+        tags$td(yes()),
+        tags$td(no()),
+        tags$td(no()),
+        tags$td(no())
+        )#,
+      # Links to functions used for DGE for each object class
+      # tags$tr(
+      #   tags$td("Function ran for DGE results"),
+      #   tags$td("presto::wilcoxauc"),
+      #   tags$td("BPcells::marker_features"),
+      #   tags$td("NA"),
+      #   tags$td("scanpy.tl.rank_genes_groups")
+      #   )
+      )
+    )
+  )
+```
+
+```{r dge_additional_info, echo=FALSE, message=FALSE, warning=FALSE}
+# Information on functions used in DGE caused issues with the table formatting
+# since function names were very long, and I didn't want to break them into
+# multiple lines. Instead, I listed the functions in a separate table.
+tags$div(
+  class = "callout callout-info",
+  tags$h4("Note"),
+  tags$p(
+    paste0(
+      "The function used to perform DGE varies by object class. The functions used for each object class are listed below."
+      )
+    ),
+  # Table of functions used, with a link to each function for more info
+  tags$table(
+    # Table should take up full space in callout
+    style = "width: 100%;",
+    tags$colgroup(
+      tags$col(class = "col-md-4", span = 1),
+      tags$col(class = "col-md-8", span = 1),
+      ),
+    tags$tbody(
+      tags$tr(
+        tags$td(tags$b("Seurat")),
+        tags$td(
+          tags$a(
+            "presto::wilcoxauc", 
+            href = "https://immunogenomics.github.io/presto/reference/wilcoxauc.html"
+            )
+          )
+        ),
+      tags$tr(
+        tags$td(tags$b("Seurat v5 + BPCells")),
+        tags$td(
+          tags$a(
+            "BPcells::marker_features", 
+            href = "https://bnprks.github.io/BPCells/reference/marker_features.html"
+            )
+          )
+        ),
+      tags$tr(
+        tags$td(tags$b("anndata")),
+        tags$td(
+          tags$a(
+            "scanpy.tl.rank_genes_groups", 
+            href = "https://scanpy.readthedocs.io/en/stable/generated/scanpy.tl.rank_genes_groups.html"
+            )
+          )
+        )
+      )
+    ),
+  # Additional information on DGE function choices and why SCE is not supported
+  tags$p(
+    style = "margin-top: 15px;",
+    "scExploreR uses the most performant wilcoxon rank sum function for each object class. DGE is not available for SingleCellExperiment objects because there is no known package that can process both the standard sparse matrices and the HDF5-enabled DelayedArray matrices in these objects."
+    )
+  )
+```
+
+
+# How should objects be processed?
+
+Generally speaking, objects should be be pre-processed before loading into the browser. Pre-processing steps encompass operations such as those outlined in the [Seurat](https://satijalab.org/seurat/articles/pbmc3k_tutorial) and [Scanpy](https://scanpy.readthedocs.io/en/stable/tutorials/basics/clustering.html) docs. 
+
+Objects should have the have the following characteristics below before loading into the browser. Objects lacking these properties may load in scExploreR, but key functionality may be limited, and unexpected behavior may be observed. 
+
+Objects should have:
+
+- At least one reduction.
+- Feature expression data for at least one modality (assay in Seurat). The browser is designed for use with both unimodal or multimodal data. 
+- Normalized count data for each modality included.
+- No `NA` values in the count/normalized count data (or `NaN` values in anndata object format).
+
+::: {.callout .callout-info}
+<h4> Note </h4>
+
+If `NA` literals exist in feature expression data, the config app will stop loading the object and return an error. We did this because `NA` values in expression data are known to cause issues in the app. If you are using software that outputs count data that evaluates to `NA` in R, or `NaN` in Python, we recommend changing those values to `0`. If this causes issues with the software you are using, please [file an issue](https://github.com/amc-heme/scExploreR/issues) and mention the software name in the issue title and text.
+
+:::
+
+- No `NA` values in metadata. `NA` values for categorical metadata should be renamed from literal `NA` values to character values (`"NA"`, `"Undefined"`, `"Unspecified"`, etc.) before loading the object into the app.
+
+If you wish to load an object that doesn't meet the conditions above, feel free to [file an issue](https://github.com/amc-heme/scExploreR/issues) describing your situation. Please search the issue board for similar situations to yours before filing an issue.
+
+## Additional Preprocessing for anndata objects
+
+For anndata objects, scExploreR requires additional information to locate matrices corresponding to reductions and multimodal data. Unlike Seurat and SingleCellExperment objects, the anndata class does not specify storage locations exclusive to modalities and reductions. Instead, both are stored in `obsm`. 
+
+For scExploreR to properly locate additional modalities and reductions, you must specify the names of the matrices in `obsm` corresponding to these data types. This is done by adding two python lists to `uns`: `uns.scExploreR_assays` for additional modalities, and `uns.scExploreR_reductions` for reductions. 
+
+For example, if you have an object with surface protein measurements in `obsm.protein`, and UMAP and PCA reductions in `obsm.X_uamp` and `obsm.X_pca`, respectively, you would enter the following in uns (replacing `object` with the name of the variable you assigned to your object):
+
+```
+object.uns["scExploreR_reductions"] = ["X_umap", "X_pca"]
+
+object.uns["scExploreR_assays"] = ["protein"]
+```
+
+For an additional example, see the [object setup vignette](object_guidelines.html).

--- a/vignettes/object_guidelines.Rmd
+++ b/vignettes/object_guidelines.Rmd
@@ -105,6 +105,13 @@ output:
   padding: 5px 15px;
 }
 
+/* Remove borders beneath each row that appear in pkgdown */
+/* Only the header row will have a border*/
+.object-table tr,
+.object-table td{
+  border-style: none;
+}
+
 .object-table table{
   background-color: transparent !important;
 }
@@ -113,6 +120,7 @@ output:
 .object-table .header{
   border-style: solid;
   border-width: 0px 0px 2px 0px;
+  border-color: #3a3c3e;
 }
 
 /* Color of icons in object table indicating presence and absence of features */
@@ -391,4 +399,4 @@ object.uns["scExploreR_reductions"] = ["X_umap", "X_pca"]
 object.uns["scExploreR_assays"] = ["protein"]
 ```
 
-For an additional example, see the [object setup vignette](object_guidelines.html).
+For an additional example, see the [app setup walkthrough vignette](dataset_setup_walkthrough.html#anndata_uns_requirements).

--- a/vignettes/scRNA_Plots_Explained.Rmd
+++ b/vignettes/scRNA_Plots_Explained.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "scRNA-Seq Plots Explained"
+title: "Guide to scRNA-Seq Plots"
 output: html_document
 ---
 

--- a/vignettes/tutorial.Rmd
+++ b/vignettes/tutorial.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 This tutorial will guide you through the use of scExploreR to analyze your data. This is not a comprehensive exploration of each feature: for more information on any feature, see the [full documentation](full_documentation.html). The browser used for this tutorial is hosted here<!--[here]()-->. The dataset contains a single bone marrow and peripheral blood sample from a healthy patient (for more, see the [download page for the dataset](https://figshare.com/articles/dataset/Expression_of_197_surface_markers_and_462_mRNAs_in_15281_cells_from_blood_and_bone_marrow_from_a_young_healthy_donor/13398065), and the related [publication](https://doi.org/10.1038/s41590-021-01059-0)).
 
-Key functionality is grouped into three tabs: plots, differential expression, and gene correlations. The interface on each tab displays the plots and analysis results on the right, and the options on the left hand panel (referred to in this document as the options panel). The plots tab is selected by default, and is helpful for summarizing data and producing visualizations. While this is a good place to get an overview your dataset, some biological questions may be best answered by starting in different tabs. This vignette will walk through common biological questions and how to approach them using the app.
+Key functionality is grouped into two <!--three--> tabs: plots and differential expression. <!--and gene correlations.--> The interface on each tab displays the plots and analysis results on the right, and the options on the left hand panel (referred to in this document as the options panel). The plots tab is selected by default, and is helpful for summarizing data and producing visualizations. While this is a good place to get an overview your dataset, some biological questions may be best answered by starting in different tabs. This vignette will walk through common biological questions and how to approach them using the app.
 
 # In which cell types is my gene deferentially expressed?
 
@@ -107,6 +107,7 @@ On the plot, there are two peaks for CD34 expression. Most cells appear either n
 
 After pressing **"Update"** to run the analysis, the results will show genes expressed to a greater extent in CD34+ (high) cells versus CD34- (low) ones. When sorting the table by AUC, several good markers for both groups appear.
 
+<!--
 # What genes in the dataset are correlated with my gene?
 
 The correlations tab can be used, among other things, to determine which genes are co-expressed with a given gene in a sample. In this example, we will analyze the correlation of other genes with CXCR4, [a top marker for the peripheral blood dendritic cells](#marker-by-sample).
@@ -119,4 +120,4 @@ The results will show the person correlation coefficients for both the full data
 
 ![](tutorial-014_Correlation_Scatterplots.gif){.centered-image width="650"}
 
-To view correlation results for a particular gene of interest, you can search for it using the text box below the "Feature" column header on the table.
+To view correlation results for a particular gene of interest, you can search for it using the text box below the "Feature" column header on the table. -->


### PR DESCRIPTION
- Added a vignette describing guidelines for processing objects for the app (#277). The vignette includes a table describing the differences in functionality between object classes (#274), and a table with links to the functions ran under the hood for DGE in each object class.
- The titles of vignettes were changed to better align with their titles under the "Articles" dropdown menu.
- Remaining mentions of the correlations tab were commented out.