### PR TITLE
Resolve DGE bug

### DIFF
--- a/R/module-dge_tab.R
+++ b/R/module-dge_tab.R
@@ -1204,7 +1204,7 @@ dge_tab_server <- function(id,
               # Header for simple thresholding
               glue("Differential Expression Results Based on
                    {feature_label} Expression Threshold")
-            } else {z
+            } else {
               # Standard DGE or metaclusters: add group by category to
               # header text
               # Label for group by category in config file

--- a/R/module-dge_table_filter.R
+++ b/R/module-dge_table_filter.R
@@ -548,7 +548,7 @@ dge_table_filtering_server <-
         observe({
           req(dge_table())
           
-          target <- "auc_ui"
+          target <- "auc_header"
           
           if ("auc" %in% colnames(dge_table())){
             shinyjs::showElement(
@@ -817,6 +817,18 @@ dge_table_filtering_server <-
             }
           })
         
+        ## 5.3 AUC ####
+        # Explicitly return NULL if "auc" does not appear in the table
+        # Avoids issue 350
+        auc <-
+          reactive({
+            if ("auc" %in% colnames(dge_table())){
+              input$auc
+              } else {
+                NULL
+                }
+            })
+        
         # 6. Return filter inputs ####
         return(
           list(
@@ -824,7 +836,7 @@ dge_table_filtering_server <-
             `feature` = reactive({input$feature}),
             `expression` = expr_value,
             `lfc` = lfc_value,
-            `auc` = reactive({input$auc}),
+            `auc` = auc,
             # pval_adj selection must be converted to numeric before returning
             `pval_adj` = reactive({as.numeric(input$pval_adj)}),
             `pct_in` = reactive({input$pct_in}),


### PR DESCRIPTION
#350 was caused by an attempt to filter on the auc column, which is not present in DGE results from anndata objects. The UI for filtering based on AUC was shown when it shouldn't have been, and a server value was being logged for AUC thresholds was likewise being reported when NULL should have been returned instead, which would have prevented filtering based on auc value. This has been corrected here.

A bug related to a typo in the DGE tab module creating a reference to `z` that does not exist was also fixed.