### PR TITLE
Dynamically re-size app body

### DIFF
--- a/inst/css/fancy_scroll.css
+++ b/inst/css/fancy_scroll.css
@@ -1,19 +1,23 @@
 /* Sidebar Scrolling properties */
 .col-sm-4{
     overflow-y: auto;
-	max-height: 85vh;
+	/* Height set using a CSS variable set by the JavaScript at 
+	   ../js/Responsive_header.js */
+	max-height: var(--body-height);
 	}
 
 /* Main Window */
 .col-sm-8{
 	overflow-y: auto;
 	overflow-x: auto;
-	max-height: 85vh;
+	/* Height set using a CSS variable set by the JavaScript at 
+	   ../js/Responsive_header.js */
+	max-height: var(--body-height);
 	}
 
 /* Loading Spinner Containers for Main Window*/
 .spinner-container-main{
-	height: 85vh;
+	height: var(--body-height);
 }
 
 /* Stack Overflow Style Scrollbar (applies to the main window and the sidebar

--- a/inst/js/Responsive_header.js
+++ b/inst/js/Responsive_header.js
@@ -1,9 +1,18 @@
-// Dynamically changes the padding of "body" to match the size of the header
+// Dynamically changes the padding and height of "body" to match the size 
+// of the header
 
 function dynamicResize(){
   // Define value of spacing (difference in window heights plus 15)
-  var dynamicSpacing = $("nav").position().top + $("nav").height() + 15;
-  // Apply value to <body>
+  const dynamicSpacing = $("nav").position().top + $("nav").height() + 15;
+
+  // Define height of main window: size of the window, minus the spacing computed above
+  const body_height = window.innerHeight - dynamicSpacing;
+
+  // Store the body height in a CSS variable, used to set the col-sm-* classes 
+  // in ../css/fancy_scroll.css
+  document.documentElement.style.setProperty('--body-height', `${body_height}px`);
+
+  // Apply dynamic spacing value to <body>
   $("body").css("padding-top", dynamicSpacing);
 }
 


### PR DESCRIPTION
Previously, the heights of the sidebar and main panels of the app were set to 85% of the window height, which resulted in white space at the bottom of the screen that is visually unappealing and limits the space available for the user to interact with the UI.

Now, the heights of these elements are set to precisely the height of the window minus the size of the navbar and spacing, previously set by the dynamicResize function.

The body of the app now extends to the bottom of the screen, without white space at the bottom. This resolves #159. 