### PR TITLE
Fix bug with error message implementation

### DIFF
--- a/R/module-dge_tab.R
+++ b/R/module-dge_tab.R
@@ -955,7 +955,7 @@ dge_tab_server <- function(id,
               # Use error_handler to display notification to user
               error_handler(
                 session,
-                cnd_message = err_cnd$message,
+                err_cnd = err_cnd,
                 # Uses a list of
                 # subset-specific errors
                 error_list = error_list$subset_errors


### PR DESCRIPTION
There was a call to the new error_handler function in the dge_tab that used the old syntax, which would have crashed the app if the tryCatch statement was triggered. This has been corrected.