### PR TITLE
Fix critical error with SCE objects

### DIFF
--- a/R/methods-assay_names.R
+++ b/R/methods-assay_names.R
@@ -55,7 +55,9 @@ assay_names.SingleCellExperiment <-
     object
   ){
     # SingleCellExperiment objects: return names of main, alternate experiments
-    c(mainExpName(object), altExpNames(object))
+    c(SingleCellExperiment::mainExpName(object), 
+      SingleCellExperiment::altExpNames(object)
+      )
   }
 
 #' @describeIn assay_names Anndata objects

--- a/R/run_scExploreR.R
+++ b/R/run_scExploreR.R
@@ -2128,9 +2128,9 @@ run_scExploreR <-
       is_anndata <-
         reactive({
           req(config())
-
+          
           if (!is.null(config()$object_class)){
-            if (config()$object_class %in% c("AnnDataR6")){
+            if ("AnnDataR6" %in% config()$object_class){
               TRUE
             } else {
               FALSE
@@ -2146,7 +2146,7 @@ run_scExploreR <-
           req(config())
           
           if (!is.null(config()$object_class)){
-            if (config()$object_class %in% c("md._core.mudata.MuData")){
+            if ("md._core.mudata.MuData" %in% config()$object_class){
               TRUE
             } else {
               FALSE


### PR DESCRIPTION
The error described in #394 was fixed by specifying the package from which mainExpName() was called in assay_names.R. 