### PR TITLE
Update presto dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,7 +91,7 @@ Imports:
     waiter (>= 0.2.5),
     yaml
 Remotes: 
-    github::immunogenomics/presto,
+    github::amc-heme/presto,
     github::amc-heme/SCUBA,
     github::amc-heme/scDE
 Encoding: UTF-8


### PR DESCRIPTION
The original immunogenomics version of presto no longer works with the latest version of SeuratObject. It was determined for now that the optimal solution is to maintain a fork of presto in the amc-heme repo. scDE was updated to depend on the fork, and scExploreR has also been updated to avoid a dependency conflict.