### PR TITLE
Fix DimPlot label crash when group_by == split_by (#309)

### DIFF
--- a/R/config_app_module-preview_dimplot.R
+++ b/R/config_app_module-preview_dimplot.R
@@ -132,7 +132,33 @@ preview_dimplot_server <-
             }
         })
         
-        # 2. Load plot selections from file ####
+        # 2. Disable/reset label checkbox when group_by == split_by ####
+        # Mirrors the equivalent guard in module-plot_module.R (see #309):
+        # Seurat::LabelClusters errors when asked to label a DimPlot whose
+        # group_by and split_by are the same variable. Disabling alone does
+        # not clear an existing TRUE value, so the value is also forced off.
+        observe({
+          req(input$group_by)
+          req(input$split_by)
+
+          if (input$group_by == input$split_by){
+            shinyjs::disable(id = "label")
+
+            updateCheckboxInput(
+              session,
+              inputId = "label",
+              value = FALSE
+              )
+          } else {
+            shinyjs::enable(id = "label")
+
+            # Do not modify the value of the checkbox in other cases
+            # (otherwise the checkbox would be reset to TRUE each time
+            # the user changes group_by and split_by)
+          }
+        })
+
+        # 3. Load plot selections from file ####
         observeEvent(
           session$userData$config(),
           {
@@ -204,7 +230,7 @@ preview_dimplot_server <-
             }
         })
         
-        # 3. return selected options ####
+        # 4. return selected options ####
         list(
           `group_by` = reactive({input$group_by}),
           `split_by` = reactive({input$split_by}),

--- a/R/module-plot_module.R
+++ b/R/module-plot_module.R
@@ -2202,13 +2202,22 @@ plot_module_server <- function(id,
                      req(plot_selections$group_by())
                      req(plot_selections$split_by())
                      
-                     if (plot_selections$group_by() == 
+                     if (plot_selections$group_by() ==
                          plot_selections$split_by()){
                        # Disable checkbox
                        shinyjs::disable(
                          id = "label"
                          )
-                       
+
+                       # Disabling alone does not clear an existing TRUE
+                       # value, which would still crash Seurat::LabelClusters
+                       # (see #309); force it off.
+                       updateCheckboxInput(
+                         session,
+                         inputId = "label",
+                         value = FALSE
+                         )
+
                        # Change the tootip over the label checkbox
                        # Remove existing tooptip, add a new one explaining why
                        # the checkbox was disabled.


### PR DESCRIPTION
## Summary
- Closes the gap left by #309: `Seurat::LabelClusters` errors (`Length of labels (N) must be equal to the number of clusters being labeled (M)` / `missing values are not allowed in subscripted assignments of data frames`) when a DimPlot's `group_by` and `split_by` are the same variable and label groups is enabled.
- The existing guard (`module-plot_module.R`, main plots tab) disabled the "Label Groups" checkbox in this case but never reset an existing `TRUE` value, so the crash could still happen. It also didn't cover the config app's dimplot preview (`config_app_module-preview_dimplot.R`), which had no guard at all.
- Both modules now force the checkbox value to `FALSE` (not just disabled) when `group_by == split_by`, and re-enable without changing the value once the selections differ again — matching the original author's stated intent in the surrounding comments.

Found while testing the Docker deployment work (#418/#419): the config app's dimplot preview crashed with this error, which turned out to be a pre-existing, unrelated bug rather than anything introduced by that work.

## Test plan
- [ ] In the config app's dataset preview, set "Metadata to Group By" and "Metadata to Split By" to the same variable with "Label Groups" checked — confirm no crash and the checkbox disables/unchecks
- [ ] In the main browser's plots tab (DimPlot), repeat the same test
- [ ] Confirm the checkbox re-enables when the two selections differ again, without unexpectedly resetting to checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)